### PR TITLE
deal with waitpid being called outside of P::FM

### DIFF
--- a/lib/Parallel/ForkManager.pm
+++ b/lib/Parallel/ForkManager.pm
@@ -623,38 +623,39 @@ sub set_max_procs {
   $s->{max_proc} = $mp;
 }
 
-# OS dependant code follows...
-
 sub _waitpid { # Call waitpid() in the standard Unix fashion.
-  return waitpid($_[1],$_[2]);
+    my( $self, $pid, $flag ) = @_;
+
+    return $flag ? $self->_waitpid_non_blocking : $self->_waitpid_blocking;
 }
 
-# On ActiveState Perl 5.6/Win32 build 625, waitpid(-1, &WNOHANG) always
-# blocks unless an actual PID other than -1 is given.
-sub _NT_waitpid {
-  my ($s, $pid, $par) = @_;
+sub _waitpid_non_blocking {
+    my $self = shift;
 
-  if ($par == &WNOHANG) { # Need to nonblock on each of our PIDs in the pool.
-    my @pids = keys %{ $s->{processes} };
-    # Simulate -1 (no processes awaiting cleanup.)
-    return -1 unless scalar(@pids);
-    # Check each PID in the pool.
-    my $kid;
-    foreach $pid (@pids) {
-      $kid = waitpid($pid, $par);
-      return $kid if $kid != 0; # AS 5.6/Win32 returns negative PIDs.
+    for my $pid ( $self->running_procs ) {
+        my $p = waitpid $pid, &WNOHANG or next;
+        if ( $p == -1 ) {
+            warn "child process '$pid' disappeared. A call to `waitpid` outside of Parallel::ForkManager might have reaped it.\n";
+            # it's gone. let's clean the process entry
+            delete $self->{processes}{$pid};
+        }
+        else {
+            return $pid;
+        }
     }
-    return $kid;
-  } else { # Normal waitpid() call.
-    return waitpid($pid, $par);
-  }
+
+    return 0;
 }
 
-{
-  local $^W = 0;
-  if ($^O eq 'NT' or $^O eq 'MSWin32') {
-    *_waitpid = \&_NT_waitpid;
-  }
+sub _waitpid_blocking {
+    my $self = shift;
+
+    while() {
+        my $pid = $self->_waitpid_non_blocking;
+        return $pid if $pid;
+
+        sleep 1;
+    }
 }
 
 sub DESTROY {

--- a/t/waitpid-conflict.t
+++ b/t/waitpid-conflict.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;                      # last test to print
+
+use Parallel::ForkManager;
+
+my $pm = Parallel::ForkManager->new(4);
+
+local $SIG{ALRM} = sub {
+    fail "test hanging, forever waiting for child process";
+    exit;
+};
+alarm 4;
+
+for ( 1..4 ) {
+    $pm->start and next;
+    sleep 1;
+    $pm->finish;
+}
+
+my $pid = waitpid -1, 0;
+
+warn "code outside of P::FM stole $pid";
+
+$pm->wait_all_children;
+
+pass "all children are accounted for";


### PR DESCRIPTION
Without this patch, the fork manager will wait
forever for its child if different a `waitpid -1, *`
reaped it. The best I could do to fix that situation is
to turn the blocking call to `waitpid` into a loop that
check for the status of all children (and only our children)
every second.

Two things you might want to do:
1. make the pulling delay configurable.
2. if you're loath to change the core of P::FM into a loop,
   I can change the patch such that we kepe the current default
   behavior, and adopt the new behavior only if explicitly specified
   (so, say, via a `set_careful()` method)
